### PR TITLE
Rebrand from eoscr to edenia for github org transfer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+### Title
+
+### What does this PR do?
+
+- Resolve #issueNumber
+
+### Steps to test
+
+1. first step
+2. next step
+
+#### CheckList
+
+- [ ] Follow proper Markdown format
+- [ ] The content is adequate
+- [ ] The content is available in both english and spanish
+- [ ] I Ran a spell check

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-<p align="center">
-	<a href="https://eoscostarica.io">
-		<img src="https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/fullColor-horizontal-transparent-white.png" width="350" alt="MIT">
+<div align="center">
+	<a href="https://edenia.com">
+		<img src="https://raw.githubusercontent.com/edenia/.github/master/.github/workflows/images/edenia-logo.png" width="300" alt="Edenia Logo">
 	</a>
-</p>
+	
+![](https://img.shields.io/github/license/edenia/eden-member-check) 
+![](https://img.shields.io/badge/code%20style-standard-brightgreen.svg) 
+![](https://img.shields.io/badge/%E2%9C%93-collaborative_etiquette-brightgreen.svg) 
+![](https://img.shields.io/twitter/follow/edeniaWeb3.svg?style=social&logo=twitter) 
+![](https://img.shields.io/github/forks/edenia/eden-member-check?style=social)
+
+</div>
 
 # Eden Member Check
 
@@ -96,22 +103,22 @@ It is necessary to have the CLSDK installed to get it working because some of th
 To read Eden Members table is needed to first have a small understanding of some basic function or definition of Eden contract use.
 
 #### EDEN_FORWARD_MEMBERS
-It is C++ definition that allow to specify and indicate which fields belongs to the specified struct, here in [member struct](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L82) we can check that `struct member` has a value of `member_variant` which represents the `member_v0` or `member_v1` fields.
+It is C++ definition that allow to specify and indicate which fields belongs to the specified struct, here in [member struct](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L82) we can check that `struct member` has a value of `member_variant` which represents the `member_v0` or `member_v1` fields.
 
 #### EDEN_FORWARD_FUNCTIONS
-It is as similar as [EDEN_FORWARD_MEMBERS](#eden_forward_members), but It's purpose is for [struct functions](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L55-L59) instead of fields.
+It is as similar as [EDEN_FORWARD_MEMBERS](#eden_forward_members), but It's purpose is for [struct functions](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L55-L59) instead of fields.
 
 #### EOSIO_REFLECT
-Indicate to the serializer which fields to handle, and clsdk's ABI generator which fields to include, as It happens in [member_v0](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L61), [member_v1](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L70) and [member](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L93).
+Indicate to the serializer which fields to handle, and clsdk's ABI generator which fields to include, as It happens in [member_v0](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L61), [member_v1](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L70) and [member](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L93).
 
 #### EOSIO_ACTIONS
-Receive the contract class, contract account and the list of [action](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L127) that are going to be needed by the serializer.
+Receive the contract class, contract account and the list of [action](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/include/edenmember.hpp#L127) that are going to be needed by the serializer.
 
 #### EOSIO_ACTION_DISPATCHER
-Take the namespace as input to get the actions that were defined into the [namespace](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/src/edenmember.cpp#L18) scope.
+Take the namespace as input to get the actions that were defined into the [namespace](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/src/edenmember.cpp#L18) scope.
 
 #### EOSIO_ABIGEN
-Last step is to generate the [abi](https://github.com/eoscostarica/eden-member-check/blob/main/contracts/edenmember/src/edenmember.cpp#L20) according to the before configuration, so then we need to indicate the actions, tables that are going to be public, and the Ricardian Clauses.
+Last step is to generate the [abi](https://github.com/edenia/eden-member-check/blob/main/contracts/edenmember/src/edenmember.cpp#L20) according to the before configuration, so then we need to indicate the actions, tables that are going to be public, and the Ricardian Clauses.
 
 Once that is understood, let's jump into some small snippet code examples.
 
@@ -170,10 +177,6 @@ bool is_eden(name account) {
 }
 ```
 
-## License
-
-MIT © [EOS Costa Rica](https://eoscostarica.io/)
-
 ## Contributing
 
 If you want to contribute to this repository, please follow the steps below:
@@ -184,20 +187,28 @@ If you want to contribute to this repository, please follow the steps below:
 4. Push the commit (`git push origin feat/sometodo`)
 5. Open a Pull Request
 
-Read the EOS Costa Rica open source [contribution guidelines](https://guide.eoscostarica.io/docs/open-source-guidelines/) for more information on scheduling conventions.
+Read the EOS Costa Rica's open source [contribution guidelines](https://guide.eoscostarica.io/docs/open-source-guidelines/) for more information on scheduling conventions.
 
-If you find any bugs, please report them by opening an issue at [this link](https://github.com/eoscostarica/eden-member-check/issues).
+If you find any bugs, please report them by opening an issue at [this link](https://github.com/edenia/eden-member-check/issues).
 
 ## What is EOSIO?
 
 EOSIO is a highly performant open-source blockchain platform, built to support and operate safe, compliant, and predictable digital infrastructures.
 
-## About EOS Costa Rica
+## About Edenia
 
-<p align="center">
-<img src="https://raw.githubusercontent.com/eoscostarica/design-assets/master/logos/eosCR/fullColor-horizontal-transparent-white.png" width="400" >
-</p>
+<div align="center">
 
-EOS Costa Rica is an independently-owned, self-funded, bare-metal Genesis block producer that provides stable and secure infrastructure for EOSIO blockchains. We support open source software for our community while offering enterprise solutions and custom smart contract development for our clients.
+<a href="https://edenia.com">
+	<img width="300" alt="Edenia Logo" src="https://raw.githubusercontent.com/edenia/.github/master/.github/workflows/images/edenia-logo.png"></img>
+</a>
 
-[eoscostarica.io](https://eoscostarica.io/)
+[![Twitter](https://img.shields.io/twitter/follow/EdeniaWeb3?style=for-the-badge)](https://twitter.com/EdeniaWeb3)
+[![Discord](https://img.shields.io/discord/946500573677625344?color=black&label=Discord&logo=discord&logoColor=white&style=for-the-badge)](https://discord.gg/YeGcF6QwhP)
+
+
+</div>
+
+Edenia runs independent blockchain infrastructure and develops web3 solutions. Our team of technology-agnostic builders has been operating since 1987, leveraging the newest technologies to make the internet safer, more efficient, and more transparent.
+
+[edenia.com](https://edenia.com/)

--- a/contracts/edenmember/include/edenmember.hpp
+++ b/contracts/edenmember/include/edenmember.hpp
@@ -2,14 +2,14 @@
 
 /*
  * @file
- * @author  (C) 2021 by eoscostarica [ https://eoscostarica.io ]
+ * @author  (C) 2021 by edenia [ https://edenia.com ]
  * @version 1.1.0
  *
  * @section DESCRIPTION
  *
  *    Smart contract edenmember 
  *
- *    GitHub:         https://github.com/eoscostarica/eden-member-check
+ *    GitHub:         https://github.com/edenia/eden-member-check
  *
  */
 
@@ -101,7 +101,7 @@ namespace eosio {
     }
 } // namespace eosio
 
-namespace eoscostarica {
+namespace edenia {
     // This table is only for demostration purpose
     struct member {
         name user;
@@ -128,4 +128,4 @@ namespace eoscostarica {
                 "edenmember"_n,
                 action(addmember, user, ricardian_contract(addmember_ricardian)))
                  
-} // namespace eoscostarica
+} // namespace edenia

--- a/contracts/edenmember/ricardian/edenmember-ricardian.cpp
+++ b/contracts/edenmember/ricardian/edenmember-ricardian.cpp
@@ -1,4 +1,4 @@
-namespace eoscostarica {
+namespace edenia {
     // CONTRACTS
     const char* addmember_ricardian = R"(---
 spec_version: 0.1.0

--- a/contracts/edenmember/src/edenmember.cpp
+++ b/contracts/edenmember/src/edenmember.cpp
@@ -1,6 +1,6 @@
 #include "../include/edenmember.hpp"
 
-namespace eoscostarica {
+namespace edenia {
     void edenmember::addmember(name user) {
         require_auth(user);
         check( is_eden(user), "Given user is not an Eden Member" );
@@ -12,17 +12,17 @@ namespace eoscostarica {
             row.user = user;
         });
     }
-} // namespace eoscostarica
+} // namespace edenia
 
 
-EOSIO_ACTION_DISPATCHER(eoscostarica::actions)
+EOSIO_ACTION_DISPATCHER(edenia::actions)
 
 EOSIO_ABIGEN(
-    actions(eoscostarica::actions),
-    table("member"_n, eoscostarica::member),
-    ricardian_clause("datastorage", eoscostarica::datastorage_clause),
-    ricardian_clause("datausage", eoscostarica::datausage_clause),
-    ricardian_clause("dataownership", eoscostarica::dataownership_clause),
-    ricardian_clause("datadistribution", eoscostarica::datadistribution_clause),
-    ricardian_clause("datafuture", eoscostarica::datafuture_clause)
+    actions(edenia::actions),
+    table("member"_n, edenia::member),
+    ricardian_clause("datastorage", edenia::datastorage_clause),
+    ricardian_clause("datausage", edenia::datausage_clause),
+    ricardian_clause("dataownership", edenia::dataownership_clause),
+    ricardian_clause("datadistribution", edenia::datadistribution_clause),
+    ricardian_clause("datafuture", edenia::datafuture_clause)
 )


### PR DESCRIPTION
Rebrand in order to prepare repo for transfer to edenia github org.